### PR TITLE
보조 파일에 한글을 한글로 쓰기

### DIFF
--- a/kotexutf-core.tex
+++ b/kotexutf-core.tex
@@ -42,21 +42,9 @@
 \loop
   \uccode\count@\z@
   \lccode\count@\z@
-  \catcode\count@\active
+  \ifnum\count@<"C0 \catcode\count@\@xiipt \fi
 \ifnum\count@<"F4 \advance\count@\@ne
 \repeat
-
-\def\defineunicodeotherchar#1#2{%
-  \protected\def#1{\string#1}%
-  \ifx#2\end\else
-    \expandafter\defineunicodeotherchar\expandafter#2%
-  \fi
-}
-\defineunicodeotherchar
-  ^^80^^81^^82^^83^^84^^85^^86^^87^^88^^89^^8a^^8b^^8c^^8d^^8e^^8f%
-  ^^90^^91^^92^^93^^94^^95^^96^^97^^98^^99^^9a^^9b^^9c^^9d^^9e^^9f%
-  ^^a0^^a1^^a2^^a3^^a4^^a5^^a6^^a7^^a8^^a9^^aa^^ab^^ac^^ad^^ae^^af%
-  ^^b0^^b1^^b2^^b3^^b4^^b5^^b6^^b7^^b8^^b9^^ba^^bb^^bc^^bd^^be^^bf\end
 
 \def\defineunicodecharXX#1#2{%
   \protected\def#1##1{%

--- a/kotexutf-core.tex
+++ b/kotexutf-core.tex
@@ -42,7 +42,7 @@
 \loop
   \uccode\count@\z@
   \lccode\count@\z@
-  \ifnum\count@<"C0 \catcode\count@\@xiipt \fi
+  \ifnum\count@<"C0 \catcode\count@=12 \fi
 \ifnum\count@<"F4 \advance\count@\@ne
 \repeat
 

--- a/kotexutf-core.tex
+++ b/kotexutf-core.tex
@@ -46,7 +46,8 @@
 \ifnum\count@<"F4 \advance\count@\@ne
 \repeat
 
-\def\defineunicodecharXX#1#2{%
+\def\defineunicodecharXX#1{%
+  \ifx#1\end\else
   \protected\def#1##1{%
     \ifcsname u8:\string#1\string##1\endcsname
       \csname u8:\string#1\string##1\expandafter\endcsname
@@ -55,15 +56,15 @@
       \expandafter#1\expandafter##1%
     \fi
   }%
-  \ifx#2\end\else
-    \expandafter\defineunicodecharXX\expandafter#2%
+  \expandafter\defineunicodecharXX
   \fi
 }
 \defineunicodecharXX
           ^^c2^^c3^^c4^^c5^^c6^^c7^^c8^^c9^^ca^^cb^^cc^^cd^^ce^^cf
   ^^d0^^d1^^d2^^d3^^d4^^d5^^d6^^d7^^d8^^d9^^da^^db^^dc^^dd^^de^^df\end
 
-\def\defineunicodecharXXX#1#2{%
+\def\defineunicodecharXXX#1{%
+  \ifx#1\end\else
   \protected\def#1##1##2{%
     \ifcsname u8:\string#1\string##1\string##2\endcsname
       \csname u8:\string#1\string##1\string##2\expandafter\endcsname
@@ -72,14 +73,14 @@
       \expandafter#1\expandafter##1\expandafter##2%
     \fi
   }%
-  \ifx#2\end\else
-    \expandafter\defineunicodecharXXX\expandafter#2%
+  \expandafter\defineunicodecharXXX
   \fi
 }
 \defineunicodecharXXX
   ^^e0^^e1^^e2^^e3^^e4^^e5^^e6^^e7^^e8^^e9^^ea^^eb^^ec^^ed^^ee^^ef\end
 
-\def\defineunicodecharXXXX#1#2{%
+\def\defineunicodecharXXXX#1{%
+  \ifx#1\end\else
   \protected\def#1##1##2##3{%
     \ifcsname u8:\string#1\string##1\string##2\string##3\endcsname
       \csname u8:\string#1\string##1\string##2\string##3\expandafter\endcsname
@@ -88,8 +89,7 @@
       \expandafter#1\expandafter##1\expandafter##2\expandafter##3%
     \fi
   }%
-  \ifx#2\end\else
-    \expandafter\defineunicodecharXXXX\expandafter#2%
+  \expandafter\defineunicodecharXXXX
   \fi
 }
 \defineunicodecharXXXX

--- a/kotexutf-core.tex
+++ b/kotexutf-core.tex
@@ -19,90 +19,17 @@
 %% frenchspacing is default
 \frenchspacing
 
-%% modifying commands from utf8.def
-\def\UTFviii@two@octets#1#2{%
-  \ifx\protect\noexpand
-    \string#1\string#2%
-  \else
-    \ifx\protect\string
-      \string#1\string#2%
-    \else
-      \ifcsname u8:\string#1\string#2\endcsname
-	\csname u8:\string#1\string#2%
-	\expandafter\expandafter\expandafter\expandafter
-	\expandafter\expandafter\expandafter\endcsname
-      \else
-	\expandafter\expandafter\expandafter\expandafter
-	\expandafter\expandafter\expandafter\unihangul@two@octets
-	\expandafter\expandafter\expandafter\expandafter
-	\expandafter\expandafter\expandafter#1%
-	\expandafter\expandafter\expandafter\expandafter
-	\expandafter\expandafter\expandafter#2%
-      \fi
-    \fi
-  \fi
-}
 \def\unihangul@two@octets#1#2{%
     \expandafter\unihangulchar\expandafter{%
       \number\numexpr
 	(`#1 - 192) * 64 +
 	(`#2 - 128) \relax}}
-\def\UTFviii@three@octets#1#2#3{%
-  \ifx\protect\noexpand
-    \string#1\string#2\string#3%
-  \else
-    \ifx\protect\string
-      \string#1\string#2\string#3%
-    \else
-      \ifcsname u8:\string#1\string#2\string#3\endcsname
-	\csname u8:\string#1\string#2\string#3%
-	\expandafter\expandafter\expandafter\expandafter
-	\expandafter\expandafter\expandafter\endcsname
-      \else
-	\expandafter\expandafter\expandafter\expandafter
-	\expandafter\expandafter\expandafter\unihangul@three@octets
-	\expandafter\expandafter\expandafter\expandafter
-	\expandafter\expandafter\expandafter#1%
-	\expandafter\expandafter\expandafter\expandafter
-	\expandafter\expandafter\expandafter#2%
-	\expandafter\expandafter\expandafter\expandafter
-	\expandafter\expandafter\expandafter#3%
-      \fi
-    \fi
-  \fi
-}
 \def\unihangul@three@octets#1#2#3{%
     \expandafter\unihangulchar\expandafter{%
       \number\numexpr
 	(`#1 - 224) * 4096 +
 	(`#2 - 128) * 64 +
 	(`#3 - 128) \relax}}
-\def\UTFviii@four@octets#1#2#3#4{%
-  \ifx\protect\noexpand
-    \string#1\string#2\string#3\string#4%
-  \else
-    \ifx\protect\string
-      \string#1\string#2\string#3\string#4%
-    \else
-      \ifcsname u8:\string#1\string#2\string#3\string#4\endcsname
-	\csname u8:\string#1\string#2\string#3\string#4%
-	\expandafter\expandafter\expandafter\expandafter
-	\expandafter\expandafter\expandafter\endcsname
-      \else
-	\expandafter\expandafter\expandafter\expandafter
-	\expandafter\expandafter\expandafter\unihangul@four@octets
-	\expandafter\expandafter\expandafter\expandafter
-	\expandafter\expandafter\expandafter#1%
-	\expandafter\expandafter\expandafter\expandafter
-	\expandafter\expandafter\expandafter#2%
-	\expandafter\expandafter\expandafter\expandafter
-	\expandafter\expandafter\expandafter#3%
-	\expandafter\expandafter\expandafter\expandafter
-	\expandafter\expandafter\expandafter#4%
-      \fi
-    \fi
-  \fi
-}
 \def\unihangul@four@octets#1#2#3#4{%
     \expandafter\unihangulchar\expandafter{%
       \number\numexpr
@@ -111,6 +38,74 @@
 	(`#3 - 128) * 64 +
 	(`#4 - 128) \relax}}
 
+\count@"80
+\loop
+  \uccode\count@\z@
+  \lccode\count@\z@
+  \catcode\count@\active
+\ifnum\count@<"F4 \advance\count@\@ne
+\repeat
+
+\def\defineunicodeotherchar#1#2{%
+  \protected\def#1{\string#1}%
+  \ifx#2\end\else
+    \expandafter\defineunicodeotherchar\expandafter#2%
+  \fi
+}
+\defineunicodeotherchar
+  ^^80^^81^^82^^83^^84^^85^^86^^87^^88^^89^^8a^^8b^^8c^^8d^^8e^^8f%
+  ^^90^^91^^92^^93^^94^^95^^96^^97^^98^^99^^9a^^9b^^9c^^9d^^9e^^9f%
+  ^^a0^^a1^^a2^^a3^^a4^^a5^^a6^^a7^^a8^^a9^^aa^^ab^^ac^^ad^^ae^^af%
+  ^^b0^^b1^^b2^^b3^^b4^^b5^^b6^^b7^^b8^^b9^^ba^^bb^^bc^^bd^^be^^bf\end
+
+\def\defineunicodecharXX#1#2{%
+  \protected\def#1##1{%
+    \ifcsname u8:\string#1\string##1\endcsname
+      \csname u8:\string#1\string##1\expandafter\endcsname
+    \else
+      \expandafter\unihangul@two@octets
+      \expandafter#1\expandafter##1%
+    \fi
+  }%
+  \ifx#2\end\else
+    \expandafter\defineunicodecharXX\expandafter#2%
+  \fi
+}
+\defineunicodecharXX
+          ^^c2^^c3^^c4^^c5^^c6^^c7^^c8^^c9^^ca^^cb^^cc^^cd^^ce^^cf
+  ^^d0^^d1^^d2^^d3^^d4^^d5^^d6^^d7^^d8^^d9^^da^^db^^dc^^dd^^de^^df\end
+
+\def\defineunicodecharXXX#1#2{%
+  \protected\def#1##1##2{%
+    \ifcsname u8:\string#1\string##1\string##2\endcsname
+      \csname u8:\string#1\string##1\string##2\expandafter\endcsname
+    \else
+      \expandafter\unihangul@three@octets
+      \expandafter#1\expandafter##1\expandafter##2%
+    \fi
+  }%
+  \ifx#2\end\else
+    \expandafter\defineunicodecharXXX\expandafter#2%
+  \fi
+}
+\defineunicodecharXXX
+  ^^e0^^e1^^e2^^e3^^e4^^e5^^e6^^e7^^e8^^e9^^ea^^eb^^ec^^ed^^ee^^ef\end
+
+\def\defineunicodecharXXXX#1#2{%
+  \protected\def#1##1##2##3{%
+    \ifcsname u8:\string#1\string##1\string##2\string##3\endcsname
+      \csname u8:\string#1\string##1\string##2\string##3\expandafter\endcsname
+    \else
+      \expandafter\unihangul@four@octets
+      \expandafter#1\expandafter##1\expandafter##2\expandafter##3%
+    \fi
+  }%
+  \ifx#2\end\else
+    \expandafter\defineunicodecharXXXX\expandafter#2%
+  \fi
+}
+\defineunicodecharXXXX
+  ^^f0^^f1^^f2^^f3^^f4\end
 
 %% subfont plane and char slot
 \def\geth@ngulpl@ne@ndch@r{%

--- a/kotexutf-core.tex
+++ b/kotexutf-core.tex
@@ -38,62 +38,56 @@
 	(`#3 - 128) * 64 +
 	(`#4 - 128) \relax}}
 
-\count@"80
-\loop
+\count@"80 \loop
   \uccode\count@\z@
   \lccode\count@\z@
-  \ifnum\count@<"C0 \catcode\count@=12 \fi
-\ifnum\count@<"F4 \advance\count@\@ne
-\repeat
+  \catcode\count@=12
+\ifnum\count@<"BF \advance\count@\@ne \repeat
 
-\def\defineunicodecharXX#1{%
-  \ifx#1\end\else
-  \protected\def#1##1{%
-    \ifcsname u8:\string#1\string##1\endcsname
-      \csname u8:\string#1\string##1\expandafter\endcsname
-    \else
-      \expandafter\unihangul@two@octets
-      \expandafter#1\expandafter##1%
-    \fi
-  }%
-  \expandafter\defineunicodecharXX
-  \fi
-}
-\defineunicodecharXX
-          ^^c2^^c3^^c4^^c5^^c6^^c7^^c8^^c9^^ca^^cb^^cc^^cd^^ce^^cf
-  ^^d0^^d1^^d2^^d3^^d4^^d5^^d6^^d7^^d8^^d9^^da^^db^^dc^^dd^^de^^df\end
+\count@"C2 \loop
+  \uccode\count@\z@
+  \lccode\count@\z@
+  \begingroup
+  \lccode`\~\count@
+  \lowercase{\endgroup
+    \protected\def~##1{%
+      \ifcsname U8:\string~\string##1\endcsname
+        \csname U8:\string~\string##1\expandafter\endcsname
+      \else
+        \expandafter\unihangul@two@octets
+        \expandafter~\expandafter##1%
+      \fi }}
+\ifnum\count@<"DF \advance\count@\@ne \repeat
 
-\def\defineunicodecharXXX#1{%
-  \ifx#1\end\else
-  \protected\def#1##1##2{%
-    \ifcsname u8:\string#1\string##1\string##2\endcsname
-      \csname u8:\string#1\string##1\string##2\expandafter\endcsname
+\count@"E0 \loop
+  \uccode\count@\z@
+  \lccode\count@\z@
+  \begingroup
+  \lccode`\~\count@
+  \lowercase{\endgroup
+  \protected\def~##1##2{%
+    \ifcsname U8:\string~\string##1\string##2\endcsname
+      \csname U8:\string~\string##1\string##2\expandafter\endcsname
     \else
       \expandafter\unihangul@three@octets
-      \expandafter#1\expandafter##1\expandafter##2%
-    \fi
-  }%
-  \expandafter\defineunicodecharXXX
-  \fi
-}
-\defineunicodecharXXX
-  ^^e0^^e1^^e2^^e3^^e4^^e5^^e6^^e7^^e8^^e9^^ea^^eb^^ec^^ed^^ee^^ef\end
+      \expandafter~\expandafter##1\expandafter##2%
+    \fi }}
+\ifnum\count@<"EF \advance\count@\@ne \repeat
 
-\def\defineunicodecharXXXX#1{%
-  \ifx#1\end\else
-  \protected\def#1##1##2##3{%
-    \ifcsname u8:\string#1\string##1\string##2\string##3\endcsname
-      \csname u8:\string#1\string##1\string##2\string##3\expandafter\endcsname
-    \else
-      \expandafter\unihangul@four@octets
-      \expandafter#1\expandafter##1\expandafter##2\expandafter##3%
-    \fi
-  }%
-  \expandafter\defineunicodecharXXXX
-  \fi
-}
-\defineunicodecharXXXX
-  ^^f0^^f1^^f2^^f3^^f4\end
+\count@"F0 \loop
+  \uccode\count@\z@
+  \lccode\count@\z@
+  \begingroup
+  \lccode`\~\count@
+  \lowercase{\endgroup
+    \protected\def~##1##2##3{%
+      \ifcsname U8:\string~\string##1\string##2\string##3\endcsname
+        \csname U8:\string~\string##1\string##2\string##3\expandafter\endcsname
+      \else
+        \expandafter\unihangul@four@octets
+        \expandafter~\expandafter##1\expandafter##2\expandafter##3%
+      \fi }}
+\ifnum\count@<"F4 \advance\count@\@ne \repeat
 
 %% subfont plane and char slot
 \def\geth@ngulpl@ne@ndch@r{%


### PR DESCRIPTION
지금까지 가끔씩 `\unihangulchar{44032}` 처럼 기록되기도 했지만 이제부터는 항상 `가` 처럼 기록된다.
부수적 효과로서, 아스키 아닌 라틴 문자의 `\MakeUppercase` 가 동작하지 않고 그대로 소문자로 식자된다. 레거시텍을 이용하는 한국어 문서에서 그 정도는 감내할 수 있지 않을까.  
