### PR TITLE
adapt to changes of recent LaTeX

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,11 @@
+2021-XX-XX  Dohyun Kim  <nomos at ktug org>
+
+	Version X.X.X
+
+	* kotexutf-core.tex: allow non-ascii charecters in labels;
+	catcode of UTF-8 trailing tokens ("80 to "BF) is now 13 (active);
+	UTF-8 first byte token commands are now expandable (not protected).
+
 2015-10-13  Kangsoo Kim  <karnes at ktug org>
 
 	Version 2.1.1a

--- a/ChangeLog
+++ b/ChangeLog
@@ -2,9 +2,9 @@
 
 	Version X.X.X
 
-	* kotexutf-core.tex: allow non-ascii charecters in labels;
-	catcode of UTF-8 trailing tokens ("80 to "BF) is now 13 (active);
-	UTF-8 first byte token commands are now expandable (not protected).
+	* kotexutf-core.tex: allow non-ascii characters in labels;
+	catcodes of UTF-8 trailing tokens ("80 to "BF) are now 13 (active);
+	UTF-8 first-byte token commands are now expandable (not protected).
 
 2015-10-13  Kangsoo Kim  <karnes at ktug org>
 

--- a/kotexplain.tex
+++ b/kotexplain.tex
@@ -24,7 +24,7 @@
 %% 2007/06/24   1.0.2   lower multiple punctuations.
 %% 2007/06/14   1.0.1   \hu was too normal a CS. use \dhucs@hu intead.
 %%
-\ifx가가\else
+\ifx 가가\else
   \input kotexutf
   \expandafter\endinput
 \fi

--- a/kotexutf-core.tex
+++ b/kotexutf-core.tex
@@ -40,13 +40,13 @@
        (`#4 - 128) \relax}}
 
 \count@"80 \loop
-  \uccode\count@\z@
-  \lccode\count@\z@
+  \uccode\count@\count@
+  \lccode\count@\count@
 \ifnum\count@<"BF \advance\count@\@ne \repeat
 
 \count@"C2 \loop
-  \uccode\count@\z@
-  \lccode\count@\z@
+  \uccode\count@\count@
+  \lccode\count@\count@
   \begingroup
   \lccode`\~\count@
   \lowercase{\endgroup
@@ -72,8 +72,8 @@
 \ifnum\count@<"DF \advance\count@\@ne \repeat
 
 \count@"E0 \loop
-  \uccode\count@\z@
-  \lccode\count@\z@
+  \uccode\count@\count@
+  \lccode\count@\count@
   \begingroup
   \lccode`\~\count@
   \lowercase{\endgroup
@@ -101,8 +101,8 @@
 \ifnum\count@<"EF \advance\count@\@ne \repeat
 
 \count@"F0 \loop
-  \uccode\count@\z@
-  \lccode\count@\z@
+  \uccode\count@\count@
+  \lccode\count@\count@
   \begingroup
   \lccode`\~\count@
   \lowercase{\endgroup

--- a/kotexutf-core.tex
+++ b/kotexutf-core.tex
@@ -23,26 +23,25 @@
 \def\unihangul@two@octets#1#2{%
     \expandafter\unihangulchar\expandafter{%
       \number\numexpr
-	(`#1 - 192) * 64 +
-	(`#2 - 128) \relax}}
+       (`#1 - 192) * 64 +
+       (`#2 - 128) \relax}}
 \def\unihangul@three@octets#1#2#3{%
     \expandafter\unihangulchar\expandafter{%
       \number\numexpr
-	(`#1 - 224) * 4096 +
-	(`#2 - 128) * 64 +
-	(`#3 - 128) \relax}}
+       (`#1 - 224) * 4096 +
+       (`#2 - 128) * 64 +
+       (`#3 - 128) \relax}}
 \def\unihangul@four@octets#1#2#3#4{%
     \expandafter\unihangulchar\expandafter{%
       \number\numexpr
-	(`#1 - 240) * 262144 +
-	(`#2 - 128) * 4096 +
-	(`#3 - 128) * 64 +
-	(`#4 - 128) \relax}}
+       (`#1 - 240) * 262144 +
+       (`#2 - 128) * 4096 +
+       (`#3 - 128) * 64 +
+       (`#4 - 128) \relax}}
 
 \count@"80 \loop
   \uccode\count@\z@
   \lccode\count@\z@
-  \catcode\count@=12
 \ifnum\count@<"BF \advance\count@\@ne \repeat
 
 \count@"C2 \loop
@@ -51,12 +50,24 @@
   \begingroup
   \lccode`\~\count@
   \lowercase{\endgroup
-    \protected\def~##1{%
-      \ifcsname U8:\string~\string##1\endcsname
-        \csname U8:\string~\string##1\expandafter\endcsname
+    \def~##1{%
+      \ifincsname
+        \string~\string##1%
       \else
-        \expandafter\unihangul@two@octets
-        \expandafter~\expandafter##1%
+        \ifx\protect\relax
+          \ifcsname U8:\string~\string##1\endcsname
+            \csname U8:\string~\string##1\endcsname
+          \else
+            \expandafter\expandafter\expandafter\expandafter
+            \expandafter\expandafter\expandafter\unihangul@two@octets
+            \expandafter\expandafter\expandafter\expandafter
+            \expandafter\expandafter\expandafter~%
+            \expandafter\expandafter\expandafter\expandafter
+            \expandafter\expandafter\expandafter##1%
+          \fi
+        \else
+          \noexpand~\noexpand##1%
+        \fi
       \fi }}
 \ifnum\count@<"DF \advance\count@\@ne \repeat
 
@@ -66,13 +77,27 @@
   \begingroup
   \lccode`\~\count@
   \lowercase{\endgroup
-  \protected\def~##1##2{%
-    \ifcsname U8:\string~\string##1\string##2\endcsname
-      \csname U8:\string~\string##1\string##2\expandafter\endcsname
-    \else
-      \expandafter\unihangul@three@octets
-      \expandafter~\expandafter##1\expandafter##2%
-    \fi }}
+  \def~##1##2{%
+      \ifincsname
+        \string~\string##1\string##2%
+      \else
+        \ifx\protect\relax
+          \ifcsname U8:\string~\string##1\string##2\endcsname
+            \csname U8:\string~\string##1\string##2\endcsname
+          \else
+            \expandafter\expandafter\expandafter\expandafter
+            \expandafter\expandafter\expandafter\unihangul@three@octets
+            \expandafter\expandafter\expandafter\expandafter
+            \expandafter\expandafter\expandafter~%
+            \expandafter\expandafter\expandafter\expandafter
+            \expandafter\expandafter\expandafter##1%
+            \expandafter\expandafter\expandafter\expandafter
+            \expandafter\expandafter\expandafter##2%
+          \fi
+        \else
+          \noexpand~\noexpand##1\noexpand##2%
+        \fi
+      \fi }}
 \ifnum\count@<"EF \advance\count@\@ne \repeat
 
 \count@"F0 \loop
@@ -81,12 +106,28 @@
   \begingroup
   \lccode`\~\count@
   \lowercase{\endgroup
-    \protected\def~##1##2##3{%
-      \ifcsname U8:\string~\string##1\string##2\string##3\endcsname
-        \csname U8:\string~\string##1\string##2\string##3\expandafter\endcsname
+    \def~##1##2##3{%
+      \ifincsname
+        \string~\string##1\string##2\string##3%
       \else
-        \expandafter\unihangul@four@octets
-        \expandafter~\expandafter##1\expandafter##2\expandafter##3%
+        \ifx\protect\relax
+          \ifcsname U8:\string~\string##1\string##2\string##3\endcsname
+            \csname U8:\string~\string##1\string##2\string##3\endcsname
+          \else
+            \expandafter\expandafter\expandafter\expandafter
+            \expandafter\expandafter\expandafter\unihangul@four@octets
+            \expandafter\expandafter\expandafter\expandafter
+            \expandafter\expandafter\expandafter~%
+            \expandafter\expandafter\expandafter\expandafter
+            \expandafter\expandafter\expandafter##1%
+            \expandafter\expandafter\expandafter\expandafter
+            \expandafter\expandafter\expandafter##2%
+            \expandafter\expandafter\expandafter\expandafter
+            \expandafter\expandafter\expandafter##3%
+          \fi
+        \else
+          \noexpand~\noexpand##1\noexpand##2\noexpand##3%
+        \fi
       \fi }}
 \ifnum\count@<"F4 \advance\count@\@ne \repeat
 

--- a/kotexutf.tex
+++ b/kotexutf.tex
@@ -23,6 +23,7 @@
 
 \makeatletter
 
+\unless\ifdefined\@gobble \long\def\@gobble#1{}\fi
 \unless\ifdefined\@tempcnta \newcount\@tempcnta\fi
 \unless\ifdefined\@tempcntb \newcount\@tempcntb\fi
 \unless\ifdefined\@empty \let\@empty\empty\fi


### PR DESCRIPTION
- address conflict with siunitx package
- allow non-ascii characters in labels

To deal with these issues we have
- changed catcodes of UTF-8 trailing tokens to 13
- made expandable the first token of UTF-8 byte sequnce
-  added `ifincsname` conditional to prevent error in `csname .. endcsname`